### PR TITLE
Fix champion & item icons

### DIFF
--- a/frontend/src/pages/match/MatchDetailPage.jsx
+++ b/frontend/src/pages/match/MatchDetailPage.jsx
@@ -8,9 +8,26 @@ const costColors = { 1: '#808080', 2: '#1E823C', 3: '#156293', 4: '#87259E', 5: 
 const getCostBorderStyle = (cost) => ({ border: `2px solid ${costColors[cost] || costColors[1]}` });
 const getCostColor = (cost) => costColors[cost] || costColors[1];
 
-const Trait = ({ trait }) => ( <div style={styles.traitIcon}> <img src={trait.image_url} alt={trait.name} style={{ width: '16px', height: '16px' }} title={trait.name} /> <span>{trait.tier_current}</span> </div> );
-const Item = ({ item }) => ( <img src={item.image_url} alt={item.name} style={styles.itemImage} title={item.name} /> );
-const Unit = ({ unit }) => ( <div style={styles.unit}> <div style={{ ...styles.starsContainer, color: getCostColor(unit.cost) }}> {'★'.repeat(unit.tier)} </div> <img src={unit.image_url} alt={unit.name} style={{ ...styles.unitImage, ...getCostBorderStyle(unit.cost) }} title={unit.name} /> <div style={styles.itemsContainer}> {unit.items.map((item, index) => item.image_url && <Item key={index} item={item} />)} </div> </div> );
+const Trait = ({ trait }) => (
+  <div style={styles.traitIcon}>
+    <img src={trait.icon || trait.image_url} alt={trait.name} style={{ width: '16px', height: '16px' }} title={trait.name} />
+    <span>{trait.tier_current}</span>
+  </div>
+);
+const Item = ({ item }) => (
+  <img src={item.icon || item.image_url} alt={item.name} style={styles.itemImage} title={item.name} />
+);
+const Unit = ({ unit }) => (
+  <div style={styles.unit}>
+    <div style={{ ...styles.starsContainer, color: getCostColor(unit.cost) }}>
+      {'★'.repeat(unit.tier)}
+    </div>
+    <img src={unit.icon || unit.image_url} alt={unit.name} style={{ ...styles.unitImage, ...getCostBorderStyle(unit.cost) }} title={unit.name} />
+    <div style={styles.itemsContainer}>
+      {unit.items.map((item, index) => (item.icon || item.image_url) && <Item key={index} item={item} />)}
+    </div>
+  </div>
+);
 
 // 8명의 플레이어 정보를 보여주는 카드
 const PlayerCard = ({ participant }) => (
@@ -22,11 +39,11 @@ const PlayerCard = ({ participant }) => (
         </div>
         <div style={styles.playerDetails}>
             <div style={styles.traitsContainer}>
-            {participant.traits.map((trait, index) => trait.image_url && <Trait key={index} trait={trait} />)}
-            </div>
-            <div style={styles.unitsContainer}>
-            {participant.units.map((unit, index) => unit.image_url && <Unit key={index} unit={unit} />)}
-            </div>
+            {participant.traits.map((trait, index) => (trait.icon || trait.image_url) && <Trait key={index} trait={trait} />)}
+          </div>
+          <div style={styles.unitsContainer}>
+            {participant.units.map((unit, index) => (unit.icon || unit.image_url) && <Unit key={index} unit={unit} />)}
+          </div>
         </div>
     </div>
 );

--- a/frontend/src/pages/summoner/components/MatchCard.jsx
+++ b/frontend/src/pages/summoner/components/MatchCard.jsx
@@ -102,7 +102,7 @@ const MatchCard = ({ match, onToggle, isExpanded }) => {
             <button onClick={() => onToggle(match.matchId)} style={{ ...styles.detailButton, transform: isExpanded ? 'rotate(180deg)' : 'none' }} title={isExpanded ? '간략히' : '상세보기'}>▼</button>
           </div>
           <div style={styles.unitsContainer}>
-            {match.units.map((u, idx) => u.image_url && <Unit key={idx} unit={u} />)}
+            {match.units.map((u, idx) => (u.icon || u.image_url) && <Unit key={idx} unit={u} />)}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/summoner/components/MatchDetailContent.jsx
+++ b/frontend/src/pages/summoner/components/MatchDetailContent.jsx
@@ -63,7 +63,7 @@ const MatchDetailContent = ({ matchId, userPuuid }) => {
           {traits.map((t, i) => <Trait key={i} trait={t} showCount={false} />)}
         </div>
         <div style={styles.detailPlayerUnits}>
-          {participant.units.map((u, idx) => u.image_url && <Unit key={idx} unit={u} />)}
+          {participant.units.map((u, idx) => (u.icon || u.image_url) && <Unit key={idx} unit={u} />)}
         </div>
       </div>
     );

--- a/frontend/src/pages/summoner/components/Trait.jsx
+++ b/frontend/src/pages/summoner/components/Trait.jsx
@@ -40,12 +40,12 @@ const Trait = ({ trait, showCount = true }) => {
   const color = trait.color || '#4A5563';
   const slug = trait.name.toLowerCase().replace(/\s+/g, '');
   const fallback = `https://raw.communitydragon.org/latest/game/assets/ux/traiticons/trait_icon_14_${slug}.png`;
-  const iconSrc  = trait.image_url || fallback;
+  const iconSrc  = trait.icon || trait.image_url || fallback;
 
   const HexagonWithBorder = (
     <div style={{ ...styles.traitHexagon, backgroundColor: color }}>
       <div style={{ ...styles.traitHexagon, width: '28px', height: '28px', backgroundColor: `${color}99` }}>
-        <img src={trait.icon} alt={trait.name} style={styles.traitImg} />
+        <img src={iconSrc} alt={trait.name} style={styles.traitImg} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render units using `icon` property in match cards & details
- support `trait.icon` and `item.icon` in match detail page
- fallback for trait icon and cleanup

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68518914cd44832b8306852c4898d3db