### PR TITLE
Fix Data Dragon icon loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 RIOT_API_KEY=your_riot_api_key_here
 MONGO_URI=your_mongodb_connection_string_here
 OPENAI_API_KEY=your_openai_api_key_here
+TFT_PATCH_VERSION=
+TFT_ASSET_SOURCE=ddragon

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ A web-based platform to analyze Teamfight Tactics (TFT) meta and match data.
 ## Setup
 
 See backend and frontend instructions below.
+
+### Environment Variables
+
+`backend` uses the following optional variables to control TFT asset loading:
+
+- `TFT_PATCH_VERSION` – set to override the patch used when requesting
+  Data&nbsp;Dragon data.
+- `TFT_ASSET_SOURCE` – set to `cdragon` to load all icons from Community&nbsp;Dragon
+  instead of Data&nbsp;Dragon.


### PR DESCRIPTION
## Summary
- add optional env vars `TFT_PATCH_VERSION` and `TFT_ASSET_SOURCE`
- use env vars in the `tftData` service to allow switching all icons to CommunityDragon
- document new variables in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in frontend *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68518d660bec832b9482367a0c290b29