### PR TITLE
Add Google AI key placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 RIOT_API_KEY=your_riot_api_key_here
 MONGO_URI=your_mongodb_connection_string_here
 OPENAI_API_KEY=your_openai_api_key_here
+GOOGLE_AI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ A web-based platform to analyze Teamfight Tactics (TFT) meta and match data.
 ## Setup
 
 See backend and frontend instructions below.
+
+### Environment
+
+Copy `.env.example` to `.env` and fill in the following keys:
+
+- `RIOT_API_KEY` – Riot Games API key.
+- `MONGO_URI` – MongoDB connection string.
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `GOOGLE_AI_API_KEY` – API key used by Google AI's generative models.


### PR DESCRIPTION
## Summary
- add `GOOGLE_AI_API_KEY` placeholder in `.env.example`
- document all environment variables in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852085260ec832b9e7f8e79f47b9cde