### PR TITLE
Fix fetch API URL template in Summoner API client

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,6 +1,6 @@
 // src/api/index.js
 export const fetchSummonerDataAPI = async (region, rawName) => {
-  const response = await fetch(`/api/summoner/<span class="math-inline">\{region\}/</span>{rawName}`);
+  const response = await fetch(`/api/summoner/${region}/${rawName}`);
   if (!response.ok) {
     const errorData = await response.json();
     throw new Error(errorData.error || 'API Error');


### PR DESCRIPTION
## Summary
- fix the fetch URL by using a plain template literal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685208513838832b960fb81f4ecdc0c2