### PR TITLE
Make TFT data patch selectable

### DIFF
--- a/backend/jobs/deckAnalyzer.js
+++ b/backend/jobs/deckAnalyzer.js
@@ -18,7 +18,7 @@ const calculateTierRank = (averagePlacement, top4Rate) => {
 export const analyzeAndCacheDeckTiers = async () => {
   console.log('--- [최종] 덱 티어리스트 분석 작업 시작 ---');
   try {
-    const tftData = await getTFTData();                  // {items, champions, traits, currentSet}
+    const tftData = await getTFTData(process.env.TFT_PATCH_VERSION); // {items, champions, traits, currentSet}
     if (!tftData) {
       console.error('TFT 데이터를 불러오지 못해 덱 분석을 중단합니다.');
       return;

--- a/backend/jobs/matchCollector.js
+++ b/backend/jobs/matchCollector.js
@@ -8,7 +8,7 @@ const delay = ms => new Promise(res => setTimeout(res, ms));
 
 export const collectTopRankerMatches = async () => {
   try {
-    const tftData = await getTFTData();
+    const tftData = await getTFTData(process.env.TFT_PATCH_VERSION);
     if (!tftData) {
       console.error('TFT 데이터를 불러오지 못해 랭커 데이터 수집을 중단합니다.');
       return;

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -6,7 +6,7 @@ import getTFTData from './tftData.js';
 
 const runScheduledJobs = async () => {
     console.log('스케줄러 시작. 먼저 TFT 데이터를 로드합니다...');
-    const tftData = await getTFTData();
+    const tftData = await getTFTData(process.env.TFT_PATCH_VERSION);
     if (!tftData) {
         console.error('TFT 데이터 로딩에 실패하여 스케줄링된 작업을 실행할 수 없습니다.');
         return;


### PR DESCRIPTION
## Summary
- allow selecting TFT patch in `getTFTData`
- pass patch version from env in scheduled jobs
- keep patch aware caching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852084e0ddc832b836bf41ed074661a