### PR TITLE
Fix TFT patch version in backend

### DIFF
--- a/backend/src/services/patchService.js
+++ b/backend/src/services/patchService.js
@@ -5,7 +5,10 @@ const REALM_URL = region => `https://ddragon.leagueoflegends.com/realms/${region
 export async function fetchPatchVersion(region = 'kr') {
   try {
     const { data } = await axios.get(REALM_URL(region));
-    return data.n.champion;
+    // Data Dragon provides a separate TFT version under `n.tft`
+    // which is required when requesting tft-champions.json and
+    // related TFT data files
+    return data.n.tft;
   } catch {
     return 'latest';
   }

--- a/backend/src/services/tftData.js
+++ b/backend/src/services/tftData.js
@@ -8,7 +8,8 @@ const REGION = 'kr';
 async function fetchPatchVersion() {
   try {
     const res = await axios.get(`https://ddragon.leagueoflegends.com/realms/${REGION}.json`);
-    return res.data.n.champion;
+    // TFT 전용 버전(n.tft)을 사용해야만 tft-champions.json 등이 존재합니다
+    return res.data.n.tft;
   } catch (err) {
     console.error('⚠️ 패치 버전 조회 실패, latest로 폴백합니다:', err.message);
     return 'latest';


### PR DESCRIPTION
## Summary
- fetch TFT patch version using `n.tft`
- update legacy service helper to use the same TFT-specific version

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852517a9178832b88ebf92be466e384