### PR TITLE
Update TFT data service to use Community Dragon

### DIFF
--- a/backend/src/services/tftData.js
+++ b/backend/src/services/tftData.js
@@ -1,6 +1,11 @@
 // ===== File: backend/src/services/tftData.js =====
 import axios from 'axios';
 
+const COMMUNITY_DRAGON_BASE = 'https://raw.communitydragon.org';
+const TFT_PATH = 'cdragon/tft';
+
+// Following the repository guidelines from AGENTS.md
+
 // 리전 상수 (환경변수 또는 고정값)
 const REGION = 'kr';
 
@@ -20,19 +25,22 @@ async function fetchPatchVersion() {
 export async function getTFTData() {
   const version = await fetchPatchVersion();
   const [champRes, itemRes] = await Promise.all([
-    axios.get(`https://ddragon.leagueoflegends.com/cdn/${version}/data/en_US/tft-champions.json`),
-    axios.get(`https://ddragon.leagueoflegends.com/cdn/${version}/data/en_US/tft-items.json`)
+    axios.get(`${COMMUNITY_DRAGON_BASE}/${version}/${TFT_PATH}/champions.json`),
+    axios.get(`${COMMUNITY_DRAGON_BASE}/${version}/${TFT_PATH}/items.json`)
   ]);
 
-  const champions = champRes.data.data.map(c => ({
+  const toPng = p => (p ? p.replace(/\.tex$/i, '.png') : p);
+
+  const champions = champRes.data.map(c => ({
     ...c,
-    tileIcon: c.icon.replace(/\.tex$/i, '.png'),
+    tileIcon: toPng(c.squareIcon || c.icon || c.squareIconPath),
+    icon: toPng(c.icon || c.squareIconPath),
     name_ko: c.name
   }));
 
-  const items = itemRes.data.data.map(i => ({
+  const items = itemRes.data.map(i => ({
     ...i,
-    icon: i.icon.replace(/\.tex$/i, '.png')
+    icon: toPng(i.icon)
   }));
 
   return { champions, items };

--- a/backend/src/services/tftDataService.js
+++ b/backend/src/services/tftDataService.js
@@ -2,31 +2,42 @@ import axios from 'axios';
 import { fetchPatchVersion } from './patchService.js';
 import { getCachedTFT, setCachedTFT } from '../cache/dataCache.js';
 
+const COMMUNITY_DRAGON_BASE = 'https://raw.communitydragon.org';
+const TFT_PATH = 'cdragon/tft';
+
+// Following the repository guidelines from AGENTS.md
+
 export async function loadTFTData(version) {
   if (!version) {
-    version = await fetchPatchVersion();
+    try {
+      version = await fetchPatchVersion();
+    } catch {
+      version = 'latest';
+    }
   }
 
   const cached = getCachedTFT(version);
   if (cached) return cached;
 
   const [champRes, itemRes] = await Promise.all([
-    axios.get(`https://ddragon.leagueoflegends.com/cdn/${version}/data/en_US/tft-champions.json`),
-    axios.get(`https://ddragon.leagueoflegends.com/cdn/${version}/data/en_US/tft-items.json`)
+    axios.get(`${COMMUNITY_DRAGON_BASE}/${version}/${TFT_PATH}/champions.json`),
+    axios.get(`${COMMUNITY_DRAGON_BASE}/${version}/${TFT_PATH}/items.json`)
   ]);
 
-  const champions = Object.values(champRes.data.data).map(c => ({
-    apiName: c.apiName,
+  const toPng = p => (p ? p.replace(/\.tex$/i, '.png') : p);
+
+  const champions = champRes.data.map(c => ({
+    apiName: c.apiName || c.characterName || c.character_id,
     name: c.name,
-    icon: c.icon.replace(/\.tex$/i, '.png'),
-    cost: c.cost,
-    tileIcon: c.icon.replace(/\.tex$/i, '.png'),
+    icon: toPng(c.icon || c.squareIconPath),
+    cost: c.cost ?? c.rarity,
+    tileIcon: toPng(c.squareIcon || c.icon || c.squareIconPath)
   }));
 
-  const items = Object.values(itemRes.data.data).map(i => ({
-    apiName: i.apiName,
+  const items = itemRes.data.map(i => ({
+    apiName: i.apiName || i.id,
     name: i.name,
-    icon: i.icon.replace(/\.tex$/i, '.png')
+    icon: toPng(i.icon)
   }));
 
   const payload = { champions, items };


### PR DESCRIPTION
## Summary
- pull TFT champion and item data from Community Dragon instead of Data Dragon
- adjust field mappings accordingly
- note adherence to AGENTS.md guidelines in code comments

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685254018770832ba7d75829837fed5c