### PR TITLE
Ensure TFT data always loads latest version

### DIFF
--- a/backend/src/services/tftData.js
+++ b/backend/src/services/tftData.js
@@ -6,24 +6,10 @@ const TFT_PATH = 'cdragon/tft';
 
 // Following the repository guidelines from AGENTS.md
 
-// 리전 상수 (환경변수 또는 고정값)
-const REGION = 'kr';
-
-// 패치 버전 조회 (에러 발생 시 'latest'로 폴백)
-async function fetchPatchVersion() {
-  try {
-    const res = await axios.get(`https://ddragon.leagueoflegends.com/realms/${REGION}.json`);
-    // TFT 전용 버전(n.tft)을 사용해야만 tft-champions.json 등이 존재합니다
-    return res.data.n.tft;
-  } catch (err) {
-    console.error('⚠️ 패치 버전 조회 실패, latest로 폴백합니다:', err.message);
-    return 'latest';
-  }
-}
-
 // TFT 데이터 로드
 export async function getTFTData() {
-  const version = await fetchPatchVersion();
+  // Community Dragon은 'latest' 버전을 지원합니다.
+  const version = 'latest';
   const [champRes, itemRes] = await Promise.all([
     axios.get(`${COMMUNITY_DRAGON_BASE}/${version}/${TFT_PATH}/champions.json`),
     axios.get(`${COMMUNITY_DRAGON_BASE}/${version}/${TFT_PATH}/items.json`)

--- a/backend/src/services/tftDataService.js
+++ b/backend/src/services/tftDataService.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { fetchPatchVersion } from './patchService.js';
 import { getCachedTFT, setCachedTFT } from '../cache/dataCache.js';
 
 const COMMUNITY_DRAGON_BASE = 'https://raw.communitydragon.org';
@@ -7,14 +6,9 @@ const TFT_PATH = 'cdragon/tft';
 
 // Following the repository guidelines from AGENTS.md
 
-export async function loadTFTData(version) {
-  if (!version) {
-    try {
-      version = await fetchPatchVersion();
-    } catch {
-      version = 'latest';
-    }
-  }
+/** 항상 최신 버전 데이터를 가져옵니다 */
+export async function getTFTData() {
+  const version = 'latest';
 
   const cached = getCachedTFT(version);
   if (cached) return cached;
@@ -45,5 +39,5 @@ export async function loadTFTData(version) {
   return payload;
 }
 
-// Alias for backward compatibility
-export const getTFTData = loadTFTData;
+// 이전 코드와의 호환성을 위해 남겨둡니다
+export const loadTFTData = getTFTData;


### PR DESCRIPTION
## Summary
- fetch Community Dragon TFT data using the `latest` endpoint
- keep a backward-compatible `loadTFTData` alias
- update standalone service file as well

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685256d3e90c832b9e4822a6cd9e195b